### PR TITLE
Use proper swift target during linking for m1 macs

### DIFF
--- a/src-rs/build_utils.rs
+++ b/src-rs/build_utils.rs
@@ -30,7 +30,10 @@ pub struct SwiftTarget {
 const MACOS_TARGET_VERSION: &str = "12";
 
 pub fn get_swift_target_info() -> SwiftTarget {
-    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let mut arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    if arch == "aarch64" {
+        arch = "arm64".into();
+    }
     let target = format!("{}-apple-macosx{}", arch, MACOS_TARGET_VERSION);
 
     let swift_target_info_str = Command::new("swift")


### PR DESCRIPTION
I had to make this change to link correctly on my M1 macbook pro