### PR TITLE
Fix incorrect `toString` usage in the `swift_print` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ import SwiftRs
 
 @_cdecl("swift_print")
 public func swiftPrint(value: SRString) {
-    // toString() converts the SRString to a Swift String
-    print(value.toString())
+    // to_string() converts the SRString to a Swift String
+    print(value.to_string())
 }
 ```
 


### PR DESCRIPTION
The function `toString` doesn't exist on the `SRString` class, it should be `to_string` instead.