### PR TITLE
better handling of minimum macOS version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftRs",
     platforms: [
-        .macOS(.v11),
+        .macOS(.v10_10), // OS X Yosemite is the minimum supported version
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ fn build() {
 use swift_rs::build;
 
 fn build() {
-    build::link_swift();
+    build::link_swift("10.15" /* macOS Catalina */); // Ensure the same minimum supported macOS version is specified as in your `Package.swift` file.
     build::link_swift_package(PACKAGE_NAME, PACKAGE_PATH);
 
     // Other build steps
@@ -45,6 +45,22 @@ fn build() {
 ```
 
 With those steps completed, you should be ready to start using Swift code from Rust!
+
+### macOS minimum system version
+
+When using `swift-rs` you may to want to use Swift API's which are only available from a certain macOS versions. You can set the minimum version of macOS you intend to support in the `Package.swift` file of your Swift project. `swift-rs` supports `10.10` (OS X Yosemite) and later.
+
+```swift
+let package = Package(
+    // ...
+    platforms: [
+        .macOS(.v10_15 /* macOS Catalina */), // This specifies the earliest version of macOS that is supported.
+    ],
+    // ...
+)
+```
+
+If you experience the error `dyld[16008]: Library not loaded: @rpath/libswiftCore.dylib` when using `swift-rs` with [Tauri](https://tauri.app) ensure you have set your [Tauri minimum system version](https://tauri.app/v1/guides/distribution/macos/#minimum-system-version) to `10.15` or higher in your `tauri.config.json`. 
 
 ## Calling basic functions
 

--- a/example/src/build.rs
+++ b/example/src/build.rs
@@ -1,6 +1,6 @@
 use swift_rs::build;
 
 fn main() {
-    build::link_swift();
+    build::link_swift("10.15"); // Ensure this matches the version set in your `Package.swift` file.
     build::link_swift_package("swift-lib", "./swift-lib/");
 }

--- a/example/swift-lib/Package.swift
+++ b/example/swift-lib/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "swift-lib",
     platforms: [
-        .macOS(.v11),
+        .macOS(.v10_15), // macOS Catalina. Earliest version that is officially supported by Apple.
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, AttributeArgs, Item, ItemFn, ItemStruct};
+use syn::{parse_macro_input, AttributeArgs, Item, ItemStruct};
 
 #[proc_macro_attribute]
 pub fn swift_object(args: TokenStream, input: TokenStream) -> TokenStream {

--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -27,14 +27,12 @@ pub struct SwiftTarget {
     pub paths: SwiftPaths,
 }
 
-const MACOS_TARGET_VERSION: &str = "12";
-
-pub fn get_swift_target_info() -> SwiftTarget {
+pub fn get_swift_target_info(minimum_mac_os_version: &'static str) -> SwiftTarget {
     let mut arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     if arch == "aarch64" {
         arch = "arm64".into();
     }
-    let target = format!("{}-apple-macosx{}", arch, MACOS_TARGET_VERSION);
+    let target = format!("{}-apple-macosx{}", arch, minimum_mac_os_version);
 
     let swift_target_info_str = Command::new("swift")
         .args(&["-target", &target, "-print-target-info"])
@@ -45,11 +43,8 @@ pub fn get_swift_target_info() -> SwiftTarget {
     serde_json::from_slice(&swift_target_info_str).unwrap()
 }
 
-pub fn link_swift() {
-    let swift_target_info = get_swift_target_info();
-    if swift_target_info.target.libraries_require_rpath {
-        panic!("Libraries require RPath! Change minimum MacOS value to fix.")
-    }
+pub fn link_swift(minimum_mac_os_version: &'static str) {
+    let swift_target_info = get_swift_target_info(minimum_mac_os_version);
 
     swift_target_info
         .paths
@@ -62,9 +57,7 @@ pub fn link_swift() {
 
 pub fn link_swift_package(package_name: &str, package_root: &str) {
     let profile = env::var("PROFILE").unwrap();
-    
-    let package_path = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
-        .join(package_root);
+    let package_path = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join(package_root);
 
     if !Command::new("swift")
         .args(&["build", "-c", &profile])
@@ -76,11 +69,14 @@ pub fn link_swift_package(package_name: &str, package_root: &str) {
         panic!("Failed to compile swift package {}", package_name);
     }
 
-    let swift_target_info = get_swift_target_info();
-
+    let mut arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    if arch == "aarch64" {
+        arch = "arm64".into();
+    }
+    let unversioned_triple = format!("{}-apple-macosx", arch);
     let search_path = package_path
         .join(".build")
-        .join(swift_target_info.target.unversioned_triple)
+        .join(unversioned_triple)
         .join(profile);
 
     println!("cargo:rustc-link-search=native={}", search_path.display());

--- a/src-rs/types/array.rs
+++ b/src-rs/types/array.rs
@@ -1,6 +1,6 @@
 use std::{ops::Deref, ptr::NonNull};
 
-use crate::{Int, UInt, SwiftRet};
+use crate::{Int, UInt};
 
 use super::SRObject;
 


### PR DESCRIPTION
Changes: 
- `swift-rs` now supports macOS 10.10 (OS X Yosemite) or higher
- `build::link_swift` takes an argument for the minimum macOS version. Eg. `build::link_swift("10.10");`
- Some docs

Closes #3