### PR TITLE
Remove Swift Runtime Compatability Version String

### DIFF
--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -76,8 +76,8 @@ pub fn link_swift_package(package_name: &str, package_root: &str) {
     let swift_target_info = get_swift_target_info();
 
     println!(
-        "cargo:rustc-link-search=static={}.build/{}/{}",
+        "cargo:rustc-link-search=native={}.build/{}/{}",
         package_root, swift_target_info.target.unversioned_triple, profile
     );
-    println!("cargo:rustc-link-lib={}", package_name);
+    println!("cargo:rustc-link-lib=static={}", package_name);
 }

--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -76,7 +76,7 @@ pub fn link_swift_package(package_name: &str, package_root: &str) {
     let swift_target_info = get_swift_target_info();
 
     println!(
-        "cargo:rustc-link-searchx={}.build/{}/{}",
+        "cargo:rustc-link-search=static={}.build/{}/{}",
         package_root, swift_target_info.target.unversioned_triple, profile
     );
     println!("cargo:rustc-link-lib={}", package_name);

--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -8,7 +8,7 @@ pub struct SwiftTargetInfo {
     pub triple: String,
     pub unversioned_triple: String,
     pub module_triple: String,
-    pub swift_runtime_compatibility_version: String,
+    //pub swift_runtime_compatibility_version: String,
     #[serde(rename = "librariesRequireRPath")]
     pub libraries_require_rpath: bool,
 }
@@ -76,8 +76,8 @@ pub fn link_swift_package(package_name: &str, package_root: &str) {
     let swift_target_info = get_swift_target_info();
 
     println!(
-        "cargo:rustc-link-search=native={}.build/{}/{}",
+        "cargo:rustc-link-searchx={}.build/{}/{}",
         package_root, swift_target_info.target.unversioned_triple, profile
     );
-    println!("cargo:rustc-link-lib=static={}", package_name);
+    println!("cargo:rustc-link-lib={}", package_name);
 }


### PR DESCRIPTION
The version of Swift running on my M1 MacBook Pro does not output a runtime compatibility version string which causes the unwrap to fail in the build script. This small change should fix the issue but I am not sure how it will act on other systems so further testing is certainly required. Also removed native and static declarations as those also caused issues with my system.

Output of `swift -version` on my system
`swift-driver version: 1.26.9 Apple Swift version 5.5.1 (swiftlang-1300.0.31.4 clang-1300.0.29.6)
Target: arm64-apple-macosx12.0`