### PR TITLE
Fix memory handling, and related stuff

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Compile
         run: cargo +${{ matrix.rust }} build
       - name: Test example
-        run: cargo +${{ matrix.rust }} test --locked --verbose --test test_example
+        run: cargo +${{ matrix.rust }} test --locked --verbose --test test_example -- --ignored
       - name: Cleanup after default build
         run: cargo +${{ matrix.rust }} clean
       - name: Compile with build enabled
@@ -35,7 +35,7 @@ jobs:
       - name: Run Tests
         env:
           TEST_SWIFT_RS: "true"
-        run: cargo +${{ matrix.rust }} test --features build --locked --verbose -- --skip test_example
+        run: cargo +${{ matrix.rust }} test --features build --locked --verbose
       - name: Check Code Formatting
         if: ${{ matrix.rust == 'stable' || matrix.rust == 'beta' }}
         run: cargo +${{ matrix.rust }} fmt --all -- --check

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,8 +26,16 @@ jobs:
           rustup component add --toolchain ${{ matrix.rust }} rustfmt clippy
       - name: Compile
         run: cargo +${{ matrix.rust }} build
+      - name: Test example
+        run: cargo +${{ matrix.rust }} test --locked --verbose --test test_example
+      - name: Cleanup after default build
+        run: cargo +${{ matrix.rust }} clean
+      - name: Compile with build enabled
+        run: cargo +${{ matrix.rust }} build --features build
       - name: Run Tests
-        run: cargo +${{ matrix.rust }} test --locked --verbose
+        env:
+          TEST_SWIFT_RS: "true"
+        run: cargo +${{ matrix.rust }} test --features build --locked --verbose -- --skip test_example
       - name: Check Code Formatting
         if: ${{ matrix.rust == 'stable' || matrix.rust == 'beta' }}
         run: cargo +${{ matrix.rust }} fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Brendonovich/swift-rs"
 edition = "2018"
 exclude=["/src-swift", "*.swift"]
+build = "src-rs/test-build.rs"
 
 [lib]
 path = "src-rs/lib.rs"
@@ -14,7 +15,11 @@ path = "src-rs/lib.rs"
 [dependencies]
 base64 = "0.13.0"
 serde = { version = "1.0", features = ["derive"], optional = true}
-serde_json = {version = "1.0", optional = true}
+serde_json = { version = "1.0", optional = true }
+
+[build-dependencies]
+serde = { version = "1.0", features = ["derive"]}
+serde_json = { version = "1.0" }
 
 [dev-dependencies]
 serial_test = "0.10"

--- a/README.md
+++ b/README.md
@@ -133,13 +133,13 @@ class SquareNumberResult: NSObject {
 
 <sub><sup>Yes, this class could contain the squaring logic too, but that is irrelevant for this example
 
-An instance of this class can then be returned from `squareNumber`:
+An instance of this class can then be returned from `squareNumber` (remember to wrap it up under `toRust()`):
 
 ```swift
 @_cdecl("square_number")
 public func squareNumber(input: Int) -> SquareNumberResult {
     let output = input * input
-    return SquareNumberResult(input, output)
+    return toRust(SquareNumberResult(input, output))
 }
 ```
 
@@ -217,9 +217,10 @@ Strings can be passed between Rust and Swift through `SRString`, which can be cr
 import SwiftRs
 
 @_cdecl("swift_print")
-public func swiftPrint(value: SRString) {
-    // to_string() converts the SRString to a Swift String
-    print(value.to_string())
+public func swiftPrint(value: UnsafePointer<SRString>) {
+    // value.pointee gives us the actual SRString instance,
+    // and .to_string() converts the SRString to a Swift String
+    print(value.pointee.to_string())
 }
 ```
 
@@ -227,7 +228,7 @@ public func swiftPrint(value: SRString) {
 use swift_rs::types::SRString;
 
 extern "C" {
-    fn swift_print(value: SRString);
+    fn swift_print(value: &SRString);
 }
 
 fn main() {
@@ -235,7 +236,7 @@ fn main() {
     // This will allocate memory in Swift and copy the string
     let value: SRString = "lorem ipsum".into();
 
-    unsafe { swift_print(value) }; // Will print "lorem ipsum" to the console
+    unsafe { swift_print(&value) }; // Will print "lorem ipsum" to the console
 }
 ```
 
@@ -249,7 +250,8 @@ public func getString() -> SRString {
     let value = "lorem ipsum"
 
     // SRString can be created from a regular String
-    return SRString(value)
+    // Again, remember to wrap up the return value under toRust()
+    return toRust(SRString(value))
 }
 ```
 
@@ -296,7 +298,7 @@ class IntArray: NSObject {
 public func getNumbers() -> IntArray {
     let numbers = [1, 2, 3, 4]
 
-    return IntArray(numbers)
+    return toRust(IntArray(numbers))
 }
 ```
 
@@ -374,7 +376,7 @@ public func getTuples() -> SRObjectArray {
     ]
 
     // Type safety is only lost when the Swift array is converted to an SRObjectArray
-    return SRObjectArray(tupleArray)
+    return toRust(SRObjectArray(tupleArray))
 }
 ```
 

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -17,16 +17,15 @@ struct Test {
 }
 
 extern "C" {
-    fn get_file_thumbnail_base64(path: SRString) -> SRString;
+    fn get_file_thumbnail_base64(path: &SRString) -> SRString;
     fn get_mounts() -> SRObjectArray<Volume>;
     fn return_nullable(null: bool) -> Option<SRObject<Test>>;
 }
 
 fn main() {
     let path = "/Users";
-    let thumbnail = unsafe { get_file_thumbnail_base64(path.into()) };
-    std::fs::write("icon.txt", &thumbnail).unwrap();
-    println!("Wrote folder icon base64 to icon.txt");
+    let thumbnail = unsafe { get_file_thumbnail_base64(&path.into()) };
+    println!("length of base64 encoded thumbnail: {}", thumbnail.as_str().len());
 
     let mounts = unsafe { get_mounts() };
     println!("First Volume Name: {}", mounts[0].name);

--- a/example/swift-lib/src/lib.swift
+++ b/example/swift-lib/src/lib.swift
@@ -2,13 +2,13 @@ import SwiftRs
 import AppKit
 
 @_cdecl("get_file_thumbnail_base64")
-func getFileThumbnailBase64(path: SRString) -> SRString {
-    let path = path.to_string();
+func getFileThumbnailBase64(path_ptr: UnsafePointer<SRString>) -> SRString {
+    let path = path_ptr.pointee.to_string();
     
     let image = NSWorkspace.shared.icon(forFile: path)
     let bitmap = NSBitmapImageRep(data: image.tiffRepresentation!)!.representation(using: .png, properties: [:])!
     
-    return SRString(bitmap.base64EncodedString())
+    return toRust(SRString(bitmap.base64EncodedString()))
 }
 
 class Volume: NSObject {
@@ -74,7 +74,7 @@ func getMounts() -> SRObjectArray {
         }
     }
     
-    return SRObjectArray(validMounts)
+    return toRust(SRObjectArray(validMounts))
 }
 
 class Test: NSObject {
@@ -90,5 +90,5 @@ class Test: NSObject {
 func returnNullable(null: Bool) -> Test? {
     if (null == true) { return nil }
     
-    return Test(null)
+    return toRust(Test(null))
 }

--- a/src-rs/test-build.rs
+++ b/src-rs/test-build.rs
@@ -1,0 +1,18 @@
+//! Build script for swift-rs that is a no-op for normal builds, but can be enabled
+//! to include test swift library based on env var `TEST_SWIFT_RS=true` with the
+//! `build` feature being enabled.
+
+#[cfg(feature = "build")]
+mod build;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed={}", TEST_ENV);
+
+    #[cfg(feature = "build")]
+    if std::env::var(TEST_ENV).unwrap_or("false".into()) == "true" {
+        build::link_swift();
+        build::link_swift_package("test-swift", "tests/swift-pkg")
+    }
+}
+
+const TEST_ENV: &str = "TEST_SWIFT_RS";

--- a/src-rs/test-build.rs
+++ b/src-rs/test-build.rs
@@ -6,13 +6,11 @@
 mod build;
 
 fn main() {
-    println!("cargo:rerun-if-env-changed={}", TEST_ENV);
+    println!("cargo:rerun-if-env-changed=TEST_SWIFT_RS");
 
     #[cfg(feature = "build")]
-    if std::env::var(TEST_ENV).unwrap_or("false".into()) == "true" {
+    if std::env::var("TEST_SWIFT_RS").unwrap_or("false".into()) == "true" {
         build::link_swift();
         build::link_swift_package("test-swift", "tests/swift-pkg")
     }
 }
-
-const TEST_ENV: &str = "TEST_SWIFT_RS";

--- a/src-rs/types/object.rs
+++ b/src-rs/types/object.rs
@@ -26,7 +26,7 @@ impl<T> AsRef<T> for SRObject<T> {
 
 impl<T> Drop for SRObject<T> {
     fn drop(&mut self) {
-        unsafe { swift::release_object(self as *const _ as *const c_void) }
+        unsafe { swift::release_object(self.0.as_ref() as *const _ as *const c_void) }
     }
 }
 

--- a/src-swift/lib.swift
+++ b/src-swift/lib.swift
@@ -55,15 +55,26 @@ public class SRString: SRData {
     }
 }
 
+/**
+ Prepares `obj` to be sent to Rust. This takes a retained copy of `obj`,
+ converts it into a raw pointer, and then returns a ref to this pointer.
+ The responsibility of releasing this object from hereon, lies with Rust.
+
+ - Returns: a reference to the same object
+ */
+public func toRust<T: NSObject>(_ obj: T) -> T {
+    let ownedPtr = Unmanaged.passRetained(obj).toOpaque()
+    return Unmanaged<T>.fromOpaque(ownedPtr).takeUnretainedValue()
+}
+
 @_cdecl("allocate_string")
 func allocateString(data: UnsafePointer<UInt8>, size: Int) -> SRString {
     let buffer = UnsafeBufferPointer(start: data, count: size)
     let string = String(bytes: buffer, encoding: .utf8)!
-    let ret = SRString(string)
-    return ret
+    return toRust(SRString(string))
 }
 
 @_cdecl("release_object")
-func releaseObject(obj: UnsafePointer<AnyObject>) {
-    let _ = Unmanaged.passUnretained(obj.pointee).release();
+func releaseObject(ptr: UnsafeMutableRawPointer) {
+    let _ = Unmanaged<AnyObject>.fromOpaque(ptr).release()
 }

--- a/tests/swift-pkg/Package.swift
+++ b/tests/swift-pkg/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "test-swift",
+    platforms: [
+        .macOS(.v11),
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "test-swift",
+            type: .static,
+            targets: ["test-swift"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(name: "SwiftRs", path: "../../")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "test-swift",
+            dependencies: [.product(name: "SwiftRs", package: "SwiftRs")],
+            path: ".",
+            exclude: ["test_example.rs", "test_bindings.rs"])
+    ]
+)

--- a/tests/swift-pkg/lib.swift
+++ b/tests/swift-pkg/lib.swift
@@ -1,0 +1,6 @@
+import SwiftRs
+
+@_cdecl("get_greeting")
+func getGreeting(name: SRString) -> SRString {
+    return SRString("Hello \(name)")
+}

--- a/tests/swift-pkg/lib.swift
+++ b/tests/swift-pkg/lib.swift
@@ -1,6 +1,6 @@
 import SwiftRs
 
 @_cdecl("get_greeting")
-func getGreeting(name: SRString) -> SRString {
-    return SRString("Hello \(name)")
+func getGreeting(name: UnsafePointer<SRString>) -> SRString {
+    return toRust(SRString("Hello \(name.pointee.to_string())"))
 }

--- a/tests/swift-pkg/lib.swift
+++ b/tests/swift-pkg/lib.swift
@@ -4,3 +4,8 @@ import SwiftRs
 func getGreeting(name: UnsafePointer<SRString>) -> SRString {
     return toRust(SRString("Hello \(name.pointee.to_string())"))
 }
+
+@_cdecl("reflect_string")
+func reflectString(ptr: UnsafePointer<SRString>) -> SRString {
+    return ptr.pointee
+}

--- a/tests/test_bindings.rs
+++ b/tests/test_bindings.rs
@@ -3,60 +3,87 @@
 //! Needs to be run with the env var `TEST_SWIFT_RS=true`, to allow for
 //! the test swift code to be linked.
 
+use serial_test::serial;
 use std::{env, process::Command};
 use swift_rs::SRString;
 
-#[test]
-fn test_string() {
-    let name: SRString = "Bond".into();
-    let greeting = unsafe { get_greeting(&name) };
-    assert_eq!(greeting.as_str(), "Hello Bond");
+macro_rules! test_with_leaks {
+    ( $op:expr ) => {{
+        let leaks_env_var = "TEST_RUNNING_UNDER_LEAKS";
+        if env::var(leaks_env_var).unwrap_or_else(|_| "false".into()) == "true" {
+            let _ = $op;
+        } else {
+            // run the above codepath under leaks monitoring
+            let exe = env::current_exe().unwrap();
+
+            // codesign the binary first, so that leaks can be run
+            let debug_plist = exe.parent().unwrap().join("debug.plist");
+            let plist_path = &debug_plist.to_string_lossy();
+            std::fs::write(&debug_plist, DEBUG_PLIST_XML.as_bytes()).unwrap();
+            let status = Command::new("codesign")
+                .args([
+                    "-s",
+                    "-",
+                    "-v",
+                    "-f",
+                    "--entitlements",
+                    plist_path,
+                    &exe.to_string_lossy(),
+                ])
+                .status()
+                .expect("cmd failure");
+            assert!(status.success(), "failed to codesign");
+
+            // run leaks command to detect memory leaks
+            let status = Command::new("leaks")
+                .args(["-atExit", "--", &exe.to_string_lossy(), "--nocapture"])
+                .env(leaks_env_var, "true")
+                .status()
+                .expect("cmd failure");
+            assert!(status.success(), "leaks detected in memory pressure test");
+        }
+    }};
 }
 
 #[test]
-fn test_memory_leaks() {
-    let leaks_env_var = "TEST_RUNNING_UNDER_LEAKS";
-    if env::var(leaks_env_var).unwrap_or_else(|_| "false".into()) == "true" {
+#[serial]
+fn test_string() {
+    test_with_leaks!(|| {
+        let name: SRString = "Bond".into();
+        let greeting = unsafe { get_greeting(&name) };
+        assert_eq!(greeting.as_str(), "Hello Bond");
+    });
+}
+
+#[test]
+#[serial]
+fn test_reflection() {
+    test_with_leaks!(|| {
+        // create memory pressure
+        let name: SRString = "Bond".into();
+        for _ in 0..10000 {
+            let reflected = unsafe { reflect_string(&name) };
+            assert_eq!(name.as_str(), reflected.as_str());
+        }
+    });
+}
+
+#[test]
+#[serial]
+fn test_memory_pressure() {
+    test_with_leaks!(|| {
         // create memory pressure
         let name: SRString = "Bond".into();
         for _ in 0..10000 {
             let greeting = unsafe { get_greeting(&name) };
             assert_eq!(greeting.as_str(), "Hello Bond");
         }
-    } else {
-        // run the above codepath under leaks monitoring
-        let exe = env::current_exe().unwrap();
-
-        // codesign the binary first, so that leaks can be run
-        let debug_plist = exe.parent().unwrap().join("debug.plist");
-        let plist_path = &debug_plist.to_string_lossy();
-        std::fs::write(&debug_plist, DEBUG_PLIST_XML.as_bytes()).unwrap();
-        let status = Command::new("codesign")
-            .args([
-                "-s",
-                "-",
-                "-v",
-                "-f",
-                "--entitlements",
-                plist_path,
-                &exe.to_string_lossy(),
-            ])
-            .status()
-            .expect("cmd failure");
-        assert!(status.success(), "failed to codesign");
-
-        // run leaks command to detect memory leaks
-        let status = Command::new("leaks")
-            .args(["-atExit", "--", &exe.to_string_lossy(), "--nocapture"])
-            .env(leaks_env_var, "true")
-            .status()
-            .expect("cmd failure");
-        assert!(status.success(), "leaks detected in memory pressure test");
-    }
+    });
 }
 
 extern "C" {
     fn get_greeting(name: &SRString) -> SRString;
+    fn reflect_string(string: &SRString) -> SRString;
 }
 
 const DEBUG_PLIST_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/test_bindings.rs
+++ b/tests/test_bindings.rs
@@ -1,0 +1,16 @@
+//! Test for swift-rs bindings
+//!
+//! Needs to be run with the env var `TEST_SWIFT_RS=true`, to allow for
+//! the test swift code to be linked.
+
+use swift_rs::SRString;
+
+#[test]
+fn test_string() {
+    let greeting = unsafe { get_greeting("Bond".into()) };
+    assert_eq!(greeting.as_str(), "Hello Bond");
+}
+
+extern "C" {
+    fn get_greeting(name: SRString) -> SRString;
+}

--- a/tests/test_bindings.rs
+++ b/tests/test_bindings.rs
@@ -3,14 +3,65 @@
 //! Needs to be run with the env var `TEST_SWIFT_RS=true`, to allow for
 //! the test swift code to be linked.
 
+use std::{env, process::Command};
 use swift_rs::SRString;
 
 #[test]
 fn test_string() {
-    let greeting = unsafe { get_greeting("Bond".into()) };
+    let name: SRString = "Bond".into();
+    let greeting = unsafe { get_greeting(&name) };
     assert_eq!(greeting.as_str(), "Hello Bond");
 }
 
-extern "C" {
-    fn get_greeting(name: SRString) -> SRString;
+#[test]
+fn test_memory_leaks() {
+    let leaks_env_var = "TEST_RUNNING_UNDER_LEAKS";
+    if env::var(leaks_env_var).unwrap_or_else(|_| "false".into()) == "true" {
+        // create memory pressure
+        let name: SRString = "Bond".into();
+        for _ in 0..10000 {
+            let greeting = unsafe { get_greeting(&name) };
+            assert_eq!(greeting.as_str(), "Hello Bond");
+        }
+    } else {
+        // run the above codepath under leaks monitoring
+        let exe = env::current_exe().unwrap();
+
+        // codesign the binary first, so that leaks can be run
+        let debug_plist = exe.parent().unwrap().join("debug.plist");
+        let plist_path = &debug_plist.to_string_lossy();
+        std::fs::write(&debug_plist, DEBUG_PLIST_XML.as_bytes()).unwrap();
+        let status = Command::new("codesign")
+            .args([
+                "-s",
+                "-",
+                "-v",
+                "-f",
+                "--entitlements",
+                plist_path,
+                &exe.to_string_lossy(),
+            ])
+            .status()
+            .expect("cmd failure");
+        assert!(status.success(), "failed to codesign");
+
+        // run leaks command to detect memory leaks
+        let status = Command::new("leaks")
+            .args(["-atExit", "--", &exe.to_string_lossy(), "--nocapture"])
+            .env(leaks_env_var, "true")
+            .status()
+            .expect("cmd failure");
+        assert!(status.success(), "leaks detected in memory pressure test");
+    }
 }
+
+extern "C" {
+    fn get_greeting(name: &SRString) -> SRString;
+}
+
+const DEBUG_PLIST_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict><key>com.apple.security.get-task-allow</key><true/></dict>
+</plist>
+"#;

--- a/tests/test_example.rs
+++ b/tests/test_example.rs
@@ -6,6 +6,7 @@ use std::{
 
 /// This test tries building the code in example/ directory
 #[test]
+#[ignore]
 #[serial]
 fn test_build() {
     let status = Command::new("cargo")
@@ -21,6 +22,7 @@ fn test_build() {
 /// This test tries building the code in example/ directory, but after modifying
 /// the `package_root` in `link_swift_package()` call to not have a trailing slash.
 #[test]
+#[ignore]
 #[serial]
 fn test_link_swift_pkg_without_trailing_slash() {
     // modify build.rs of example
@@ -48,6 +50,7 @@ fn test_link_swift_pkg_without_trailing_slash() {
 ///
 /// TODO:this should be replaced with better & more structured tests
 #[test]
+#[ignore]
 #[serial]
 fn test_run() {
     let status = Command::new("cargo")


### PR DESCRIPTION
## Problem
The current model of managing memory is broken. As an example, replace the following snippet of `example/src/main.rs`:
```rust
fn main() {
    let path = "/Users";
    let thumbnail = unsafe { get_file_thumbnail_base64(path.into()) };
    println!("length of base64 encoded thumbnail: {}", thumbnail.as_str().len());

    let mounts = unsafe { get_mounts() };
    println!("First Volume Name: {}", mounts[0].name);

    let opt = unsafe { return_nullable(true) };
    println!("function returned nil: {}", opt.is_none());

    let opt = unsafe { return_nullable(false) };
    println!("function returned data: {}", opt.is_some());
}
```
with the following (essentially just running the exact same code on a non-main thread):
```rust
fn main() {
    let handle = std::thread::spawn(|| {
        let path = "/Users";
        let thumbnail = unsafe { get_file_thumbnail_base64(path.into()) };
        println!("length of base64 encoded thumbnail: {}", thumbnail.as_str().len());

        let mounts = unsafe { get_mounts() };
        println!("First Volume Name: {}", mounts[0].name);

        let opt = unsafe { return_nullable(true) };
        println!("function returned nil: {}", opt.is_none());

        let opt = unsafe { return_nullable(false) };
        println!("function returned data: {}", opt.is_some());
    };
    handle.join.unwrap();
}
```
This will break. I realised this when writing tests, and the exact code of the example wouldn't work (tests get executed on a non-main thread).

## Reason
The reason is that in the current model, when we create an object on the Swift side and pass it on to Rust, we do not disconnect it from Swift's ARC. So when the Rust side `drop`s it (thus calling a `.release()` on it via `SRObject`'s drop implementation) , Swift's ARC still assumes this object needs to be dropped, eventually dropping it in `autorelease`. This happens only when a separate thread is used.

## Fix
The recommended way to handle Swift & C-like languages interfacing, is sticking to the following rules (I've also mentioned corresponding changes done in this PR):
1. When an object is created on Swift side, and is being sent to Rust side, assuming that Rust will now be **owning** that object (in the sense of managing its lifecycle), we need to disconnect the Swift object from ARC before passing it along. To do this, I've created a `toRust()` function which does exactly that. Every `T: SRObject` return from Swift needs to be wrapped in `toRust()`.
2. Given that Rust now owns the object, once it's done with it, it needs to invoke `Unmanaged..release()` to tell Swift to free it up. The current implementation of `SRObject::drop()` does that already, but had a bug, which has been fixed in this PR.
3. When Rust sends a `SRString` object to Swift side, the only memory-safe way it can be sent, is as a reference (i.e. `&value`, not `value`). Let's take the `get_file_thumbnail_base64(path: SRString)` of example. If `path` is an `SRString` instead of `&SRString`, Rust treats it as _consumed_ in the function call. But the function here is an `extern` function, so the `drop` on `path` never gets called - a memory leak!
4. The above also means that any Swift side function which receives an `SRString` parameter, now needs to take in a `ptr: UnsafePointer<SRString>` instead, and use `ptr.pointee.to_string()` to get a Swift string.

## Cascading effects
Along with the above, this PR includes the following:
1. Tests for the `SRString` bindings - both from Rust to Swift & vice-versa. This is in `test_string()` of `tests/test_bindings.rs`. Similar tests can/should be created for other types, if this PR gets merged.
2. Tests for memory leak detection via `leaks` command. See `test_memory_leaks()` under `tests/test_binding.rs`
3. For the tests to be viable, they needed to be linked to a test swift package, which required a build script (`src-rs/test-build.rs`) and corresponding changes to `Cargo.toml`. This build script is a no-op unless specific test conditions are met, so does not create any overhead for users of this library.
4. Changes in example to use `toRust()` and accept `SRString` as a reference on Swift side (i.e. `UnsafePointer<SRString>)`
5. Documentation changes to reflect the API changes

I wish there was a non-API breaking change to do all of the above, but to the best of my knowledge, there isn't.
