### PR TITLE
fix(build): x86_64-apple-ios is a simulator target.

### DIFF
--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -85,7 +85,8 @@ enum SwiftSDK {
 impl SwiftSDK {
     fn from_os(os: &RustTargetOS) -> Self {
         let target = env::var("TARGET").unwrap();
-        let simulator = target.ends_with("ios-sim");
+        let simulator = target.ends_with("ios-sim")
+            || (target.starts_with("x86_64") && target.ends_with("ios"));
 
         match os {
             RustTargetOS::MacOS => Self::MacOS,


### PR DESCRIPTION
Fixes #39 