### PR TITLE
feat(build): add option to set output directory

### DIFF
--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "swift-rs"
-version = "1.0.0"
+version = "1.0.4"
 dependencies = [
  "base64",
  "serde",


### PR DESCRIPTION
This allows users to set a custom output directory and also skip the `--scratch-path` argument when setting the out_dir to `.build`, useful to support older Swift versions.