### PR TITLE
Create SRData from slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ for _ in 0..10000 {
 
 ## Limitations
 
-Currently, the only types that can be created from Rust are number types, boolean, `SRString`, and `SRArray`/`SRData`.
+Currently, the only types that can be created from Rust are number types, boolean, `SRString`, and `SRData`.
 This is because those types are easy to allocate memory for, either on the stack or on the heap via calling out to swift,
 whereas other types are not. This may be implemented in the future, though.
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ for _ in 0..10000 {
 
 ## Limitations
 
-Currently, the only types that can be created from Rust are number types, boolean and `SRString`.
+Currently, the only types that can be created from Rust are number types, boolean, `SRString`, and `SRArray`/`SRData`.
 This is because those types are easy to allocate memory for, either on the stack or on the heap via calling out to swift,
 whereas other types are not. This may be implemented in the future, though.
 

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "swift-rs"
-version = "1.0.0"
+version = "1.0.5"
 dependencies = [
  "base64",
  "serde",

--- a/src-rs/types/data.rs
+++ b/src-rs/types/data.rs
@@ -58,8 +58,8 @@ impl AsRef<[u8]> for SRData {
     }
 }
 
-impl From<&Vec<u8>> for SRData {
-    fn from(value: &Vec<u8>) -> Self {
+impl From<&[u8]> for SRData {
+    fn from(value: &[u8]) -> Self {
         unsafe { swift::data_from_bytes(value.as_ptr(), value.len() as Int) }
     }
 }

--- a/tests/test_bindings.rs
+++ b/tests/test_bindings.rs
@@ -134,7 +134,7 @@ swift!(fn echo_data(data: &SRData) -> SRData);
 fn test_data() {
     test_with_leaks!(|| {
         let str: &str = "hello";
-        let bytes = &str.as_bytes().to_vec();
+        let bytes = str.as_bytes();
         for _ in 0..10_000 {
             let data = unsafe { echo_data(&bytes.into()) };
             assert_eq!(data.as_slice(), bytes);


### PR DESCRIPTION
This PR updates the impl of `From` for `SRData` so that it takes `&[u8]` rather than `&Vec<u8>`. 

The implementation is the same, but allows for byte slices to owned by containers other than `Vec`.
