### PR TITLE
fix: NSObject offset size in SRObject being too small

### DIFF
--- a/src-rs/types/object.rs
+++ b/src-rs/types/object.rs
@@ -4,7 +4,7 @@ use std::{ffi::c_void, ops::Deref, ptr::NonNull};
 #[doc(hidden)]
 #[repr(C)]
 pub struct SRObjectImpl<T> {
-    _nsobject_offset: u8,
+    _nsobject_offset: *const c_void,
     data: T,
 }
 

--- a/tests/swift-pkg/lib.swift
+++ b/tests/swift-pkg/lib.swift
@@ -27,3 +27,22 @@ func complexData() -> SRObjectArray {
 func echoData(data: SRData) -> SRData {
     return SRData(data.toArray())
 }
+
+class MemoryTestData: NSObject {
+    var a: Int32
+    var b: Int32
+    var c: Int32
+    var d: Int32
+    
+    public override init() {
+        self.a = 1
+        self.b = 2
+        self.c = 3
+        self.d = 4
+    }
+}
+
+@_cdecl("get_memory_test_data")
+func createTestData() -> MemoryTestData {
+    return MemoryTestData()
+}

--- a/tests/test_bindings.rs
+++ b/tests/test_bindings.rs
@@ -148,3 +148,22 @@ const DEBUG_PLIST_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
     <dict><key>com.apple.security.get-task-allow</key><true/></dict>
 </plist>
 "#;
+
+#[repr(C)]
+struct MemoryTestData {
+    a: i32,
+    b: i32,
+    c: i32,
+    d: i32,
+}
+
+swift!(fn get_memory_test_data() -> SRObject<MemoryTestData>);
+
+#[test]
+fn test_memory_layout() {
+    let data = unsafe { get_memory_test_data() };
+    assert_eq!(data.a, 1);
+    assert_eq!(data.b, 2);
+    assert_eq!(data.c, 3);
+    assert_eq!(data.d, 4);
+}


### PR DESCRIPTION
Hi!

Thank you for this library, it have made mixing Rust and Swift a breeze!

However, I encountered a bug when I tried to implement a function which returned a class with 4 ints. The first member of the class always got the same weird number. It seems like the memory offset used in SRObject is not big enough, only taking up one byte whereas a pointer (on 64-bit systems) is 8 bytes.

Replacing the `u8` offset with `*const c_void` seems to solve this issue as Rust now allocates the size for a pointer instead of just a byte. The test I also added replicates my issue and fails with the `u8` type but passes after the change 🙂 