### PR TITLE
some refinements to `SR` types in swift

### DIFF
--- a/src-swift/lib.swift
+++ b/src-swift/lib.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class SRArray<T>: NSObject, ExpressibleByArrayLiteral {
+public final class SRArray<T>: NSObject, ExpressibleByArrayLiteral {
     public typealias ArrayLiteralElement = T
     
     // Used by Rust
@@ -9,7 +9,7 @@ public class SRArray<T>: NSObject, ExpressibleByArrayLiteral {
     
     // Actual array, deallocates objects inside automatically
     let array: [T]
-
+    
     public override init() {
         self.array = []
         self.pointer = UnsafePointer(self.array)
@@ -22,7 +22,7 @@ public class SRArray<T>: NSObject, ExpressibleByArrayLiteral {
         self.length = data.count
     }
     
-    public required init(arrayLiteral elements: T...) {
+    public init(arrayLiteral elements: T...) {
         self.array = elements
         self.pointer = UnsafePointer(elements)
         self.length = elements.count
@@ -33,13 +33,8 @@ public class SRArray<T>: NSObject, ExpressibleByArrayLiteral {
     }
 }
 
-public class SRObjectArray: NSObject {
-    let data: SRArray<NSObject>
-    
-    public init(_ data: [NSObject]) {
-        self.data = SRArray(data)
-    }
-}
+@available(*, deprecated, message: "use SRArray<NSObject> instead")
+typealias SRObjectArray = SRArray<NSObject>
 
 public class SRData: NSObject {
     let data: SRArray<UInt8>
@@ -61,7 +56,7 @@ public class SRData: NSObject {
     }
 }
 
-public class SRString: SRData, ExpressibleByStringLiteral {
+public final class SRString: SRData, ExpressibleByStringLiteral {
     public typealias StringLiteralType = String
     
     public override init() {
@@ -72,11 +67,11 @@ public class SRString: SRData, ExpressibleByStringLiteral {
         super.init(Array(string.utf8))
     }
 
-    public required init(stringLiteral value: String) {
+    public init(stringLiteral value: String) {
         super.init(Array(value.utf8))
     }
     
-    init(_ data: SRData) {
+    public init(_ data: SRData) {
         super.init(data.data)
     }
 

--- a/src-swift/lib.swift
+++ b/src-swift/lib.swift
@@ -2,14 +2,14 @@ import Foundation
 
 public final class SRArray<T>: NSObject, ExpressibleByArrayLiteral {
     public typealias ArrayLiteralElement = T
-    
+
     // Used by Rust
-    let pointer: UnsafePointer<T>
-    let length: Int
-    
+    public let pointer: UnsafePointer<T>
+    public let length: Int
+
     // Actual array, deallocates objects inside automatically
-    let array: [T]
-    
+    public let array: [T]
+
     public override init() {
         self.array = []
         self.pointer = UnsafePointer(self.array)
@@ -21,7 +21,7 @@ public final class SRArray<T>: NSObject, ExpressibleByArrayLiteral {
         self.pointer = UnsafePointer(self.array)
         self.length = data.count
     }
-    
+
     public init(arrayLiteral elements: T...) {
         self.array = elements
         self.pointer = UnsafePointer(elements)
@@ -36,17 +36,24 @@ public final class SRArray<T>: NSObject, ExpressibleByArrayLiteral {
 @available(*, deprecated, message: "use SRArray<NSObject> instead")
 public typealias SRObjectArray = SRArray<NSObject>
 
+public extension SRArray<NSObject> {
+    @available(*, deprecated, message: "this property is just for backward compatibility; use self instead.")
+    var data: Self {
+        get { self }
+    }
+}
+
 public class SRData: NSObject {
-    let data: SRArray<UInt8>
-    
+    public let data: SRArray<UInt8>
+
     public override init() {
         self.data = SRArray()
     }
-    
+
     public init(_ data: [UInt8]) {
         self.data = SRArray(data)
     }
-    
+
     public init (_ srArray: SRArray<UInt8>) {
         self.data = srArray
     }
@@ -58,7 +65,7 @@ public class SRData: NSObject {
 
 public final class SRString: SRData, ExpressibleByStringLiteral {
     public typealias StringLiteralType = String
-    
+
     public override init() {
         super.init([])
     }
@@ -70,7 +77,7 @@ public final class SRString: SRData, ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
         super.init(Array(value.utf8))
     }
-    
+
     public init(_ data: SRData) {
         super.init(data.data)
     }
@@ -81,23 +88,23 @@ public final class SRString: SRData, ExpressibleByStringLiteral {
 }
 
 @_cdecl("retain_object")
-func retainObject(ptr: UnsafeMutableRawPointer) {
+public func retainObject(ptr: UnsafeMutableRawPointer) {
     let _ = Unmanaged<AnyObject>.fromOpaque(ptr).retain()
 }
 
 @_cdecl("release_object")
-func releaseObject(ptr: UnsafeMutableRawPointer) {
+public func releaseObject(ptr: UnsafeMutableRawPointer) {
     let _ = Unmanaged<AnyObject>.fromOpaque(ptr).release()
 }
 
 @_cdecl("data_from_bytes")
-func dataFromBytes(data: UnsafePointer<UInt8>, size: Int) -> SRData {
+public func dataFromBytes(data: UnsafePointer<UInt8>, size: Int) -> SRData {
     let buffer = UnsafeBufferPointer(start: data, count: size)
     return SRData(Array(buffer))
 }
 
 @_cdecl("string_from_bytes")
-func stringFromBytes(data: UnsafePointer<UInt8>, size: Int) -> SRString {
+public func stringFromBytes(data: UnsafePointer<UInt8>, size: Int) -> SRString {
     let data = dataFromBytes(data: data, size: size);
     return SRString(data)
 }

--- a/src-swift/lib.swift
+++ b/src-swift/lib.swift
@@ -34,7 +34,7 @@ public final class SRArray<T>: NSObject, ExpressibleByArrayLiteral {
 }
 
 @available(*, deprecated, message: "use SRArray<NSObject> instead")
-typealias SRObjectArray = SRArray<NSObject>
+public typealias SRObjectArray = SRArray<NSObject>
 
 public class SRData: NSObject {
     let data: SRArray<UInt8>

--- a/src-swift/lib.swift
+++ b/src-swift/lib.swift
@@ -1,27 +1,35 @@
 import Foundation
 
-public class SRArray<T>: NSObject {
+public class SRArray<T>: NSObject, ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = T
+    
     // Used by Rust
     let pointer: UnsafePointer<T>
-    let length: Int;
+    let length: Int
     
     // Actual array, deallocates objects inside automatically
-    let array: [T];
+    let array: [T]
 
     public override init() {
-        self.array = [];
-        self.pointer = UnsafePointer(self.array);
-        self.length = 0;
+        self.array = []
+        self.pointer = UnsafePointer(self.array)
+        self.length = 0
     }
 
     public init(_ data: [T]) {
-        self.array = data;
+        self.array = data
         self.pointer = UnsafePointer(self.array)
         self.length = data.count
     }
+    
+    public required init(arrayLiteral elements: T...) {
+        self.array = elements
+        self.pointer = UnsafePointer(elements)
+        self.length = elements.count
+    }
 
     public func toArray() -> [T] {
-        return Array(self.array)
+        return self.array
     }
 }
 
@@ -53,7 +61,9 @@ public class SRData: NSObject {
     }
 }
 
-public class SRString: SRData {
+public class SRString: SRData, ExpressibleByStringLiteral {
+    public typealias StringLiteralType = String
+    
     public override init() {
         super.init([])
     }
@@ -62,6 +72,10 @@ public class SRString: SRData {
         super.init(Array(string.utf8))
     }
 
+    public required init(stringLiteral value: String) {
+        super.init(Array(value.utf8))
+    }
+    
     init(_ data: SRData) {
         super.init(data.data)
     }


### PR DESCRIPTION
- made `SRString` and `SRArray` become expressible by literals.
- found the type `SRObjectArray` a bit repetitive, since it's just basically a `SRArray<NSObject>` but with less functionality, so made a typealias for it, and marked it as deprecated 