### PR TITLE
fix: remove `base64` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 path = "src-rs/lib.rs"
 
 [dependencies]
-base64 = "0.21.0"
 serde = { version = "1.0", features = ["derive"], optional = true}
 serde_json = { version = "1.0", optional = true }
 
@@ -28,6 +27,7 @@ serde_json = { version = "1.0" }
 
 [dev-dependencies]
 serial_test = "0.10"
+base64 = "0.21.0"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ serde_json = { version = "1.0" }
 
 [dev-dependencies]
 serial_test = "0.10"
-base64 = "0.21.0"
 
 [features]
 default = []


### PR DESCRIPTION
This is not used at all. The version used here is outdated and I am trying to eliminate duplicate/outdated dependencies from my dependency tree that has `swift-rs` in it.