### PR TITLE
Fix Swift package builds on Xcode 27

### DIFF
--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -299,15 +299,13 @@ impl SwiftLinker {
                 self.visionos_min_version.as_deref(),
             );
 
-            // Xcode 27's SwiftPM appends its own host `-sdk`/`-target` *after* any
-            // `-Xswiftc` flags we pass, so the historical per-`swiftc` SDK/target
-            // overrides (below) stopped taking effect and a cross-compiled package
-            // (e.g. iOS) ended up built against the host macOS SDK, failing with
-            // errors like `could not build module 'AppKit'`. From Xcode 27 on we
-            // instead drive the whole build with `--triple`, which SwiftPM consumes
-            // itself so every `swiftc`/`clang` invocation gets a consistent
-            // SDK/target. Older toolchains keep the original behavior untouched.
-            let use_triple = xcode_major_version().map(|v| v >= 27).unwrap_or(false);
+            // Xcode 27's SwiftPM appends the host -sdk/-target after the -Xswiftc
+            // overrides below, so cross builds compile against the host SDK. Pass
+            // --triple there instead. macOS (host == target) is unaffected and
+            // keeps the legacy path.
+            let xcode27 = xcode_major_version().map(|v| v >= 27).unwrap_or(false);
+            let cross_compiling = !matches!(rust_target.os, RustTargetOS::MacOS);
+            let use_triple = cross_compiling && xcode27;
 
             command
                 // Build the package (duh)
@@ -327,13 +325,10 @@ impl SwiftLinker {
             command.args(["--build-path", &out_path.display().to_string()]);
 
             if !use_triple {
+                // Override the SDK and target on each swiftc instance.
                 command
-                    // Override SDK path for each swiftc instance.
-                    // Necessary for iOS compilation.
                     .args(["-Xswiftc", "-sdk"])
                     .args(["-Xswiftc", sdk_path.trim()])
-                    // Override target triple for each swiftc instance.
-                    // Necessary for iOS compilation.
                     .args(["-Xswiftc", "-target"])
                     .args(["-Xswiftc", &swift_target_triple]);
             }
@@ -348,15 +343,11 @@ impl SwiftLinker {
                 panic!("Failed to compile swift package {}", package.name);
             }
 
-            let search_path = if use_triple {
-                // With `--triple` SwiftPM emits products under the real target
-                // triple, so resolve through the `<configuration>` symlink it
-                // creates in the build directory rather than hard-coding the folder
-                // name (newer toolchains moved it to e.g. `out/Products/...`).
+            let search_path = if xcode27 {
+                // Xcode 27 relocated products under out/Products/*; reach them via
+                // the `<configuration>` symlink rather than a fixed path.
                 out_path.join(configuration)
             } else {
-                // The legacy path forces the build onto the host, so the products
-                // always land under `<arch>-apple-macosx`.
                 out_path
                     .join(format!("{}-apple-macosx", arch))
                     .join(configuration)
@@ -397,8 +388,7 @@ fn clang_link_search_path() -> String {
     panic!("clang is missing search paths");
 }
 
-/// The major version of the active Xcode (e.g. `27`), or `None` if it can't be
-/// determined. Used to decide how to pass the SDK/target to `swift build`.
+/// Major version of the active Xcode (e.g. `27`), or `None` if undetectable.
 fn xcode_major_version() -> Option<u32> {
     let output = Command::new("xcrun")
         .args(["xcodebuild", "-version"])
@@ -408,7 +398,7 @@ fn xcode_major_version() -> Option<u32> {
         return None;
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    // The first line looks like `Xcode 27.0`.
+    // e.g. "Xcode 27.0"
     let first_line = stdout.lines().next()?;
     let version = first_line.strip_prefix("Xcode ")?.trim();
     version.split('.').next()?.parse().ok()

--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -299,24 +299,46 @@ impl SwiftLinker {
                 self.visionos_min_version.as_deref(),
             );
 
+            // Xcode 27's SwiftPM appends its own host `-sdk`/`-target` *after* any
+            // `-Xswiftc` flags we pass, so the historical per-`swiftc` SDK/target
+            // overrides (below) stopped taking effect and a cross-compiled package
+            // (e.g. iOS) ended up built against the host macOS SDK, failing with
+            // errors like `could not build module 'AppKit'`. From Xcode 27 on we
+            // instead drive the whole build with `--triple`, which SwiftPM consumes
+            // itself so every `swiftc`/`clang` invocation gets a consistent
+            // SDK/target. Older toolchains keep the original behavior untouched.
+            let use_triple = xcode_major_version().map(|v| v >= 27).unwrap_or(false);
+
             command
                 // Build the package (duh)
                 .arg("build")
                 // SDK path for regular compilation (idk)
                 .args(["--sdk", sdk_path.trim()])
                 // Release/Debug configuration
-                .args(["-c", configuration])
-                .args(["--arch", arch])
-                // Where the artifacts will be generated to
-                .args(["--build-path", &out_path.display().to_string()])
-                // Override SDK path for each swiftc instance.
-                // Necessary for iOS compilation.
-                .args(["-Xswiftc", "-sdk"])
-                .args(["-Xswiftc", sdk_path.trim()])
-                // Override target triple for each swiftc instance.
-                // Necessary for iOS compilation.
-                .args(["-Xswiftc", "-target"])
-                .args(["-Xswiftc", &swift_target_triple])
+                .args(["-c", configuration]);
+
+            if use_triple {
+                command.args(["--triple", &swift_target_triple]);
+            } else {
+                command.args(["--arch", arch]);
+            }
+
+            // Where the artifacts will be generated to
+            command.args(["--build-path", &out_path.display().to_string()]);
+
+            if !use_triple {
+                command
+                    // Override SDK path for each swiftc instance.
+                    // Necessary for iOS compilation.
+                    .args(["-Xswiftc", "-sdk"])
+                    .args(["-Xswiftc", sdk_path.trim()])
+                    // Override target triple for each swiftc instance.
+                    // Necessary for iOS compilation.
+                    .args(["-Xswiftc", "-target"])
+                    .args(["-Xswiftc", &swift_target_triple]);
+            }
+
+            command
                 .args(["-Xcc", &format!("--target={swift_target_triple}")])
                 .args(["-Xcxx", &format!("--target={swift_target_triple}")]);
 
@@ -326,10 +348,19 @@ impl SwiftLinker {
                 panic!("Failed to compile swift package {}", package.name);
             }
 
-            let search_path = out_path
-                // swift build uses this output folder no matter what is the target
-                .join(format!("{}-apple-macosx", arch))
-                .join(configuration);
+            let search_path = if use_triple {
+                // With `--triple` SwiftPM emits products under the real target
+                // triple, so resolve through the `<configuration>` symlink it
+                // creates in the build directory rather than hard-coding the folder
+                // name (newer toolchains moved it to e.g. `out/Products/...`).
+                out_path.join(configuration)
+            } else {
+                // The legacy path forces the build onto the host, so the products
+                // always land under `<arch>-apple-macosx`.
+                out_path
+                    .join(format!("{}-apple-macosx", arch))
+                    .join(configuration)
+            };
 
             println!("cargo:rerun-if-changed={}", package_path.display());
             println!("cargo:rustc-link-search=native={}", search_path.display());
@@ -364,4 +395,21 @@ fn clang_link_search_path() -> String {
         }
     }
     panic!("clang is missing search paths");
+}
+
+/// The major version of the active Xcode (e.g. `27`), or `None` if it can't be
+/// determined. Used to decide how to pass the SDK/target to `swift build`.
+fn xcode_major_version() -> Option<u32> {
+    let output = Command::new("xcrun")
+        .args(["xcodebuild", "-version"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The first line looks like `Xcode 27.0`.
+    let first_line = stdout.lines().next()?;
+    let version = first_line.strip_prefix("Xcode ")?.trim();
+    version.split('.').next()?.parse().ok()
 }


### PR DESCRIPTION
Building Swift packages with the Xcode 27 toolchain is broken. There are two separate issues introduced in Xcode 27. Xcode 26 and earlier are unaffected, so all behavior changes are gated to Xcode 27+.

## Problems

### 1. Cross-compilation builds against the host SDK

For non-macOS targets, link builds for the host and redirects each `swiftc` invocation with:

```bash
-Xswiftc -sdk ...
-Xswiftc -target ...
```

However, Xcode 27's SwiftPM now appends its own host `-sdk` / `-target` flags after those flags, causing the earlier values to be ignored.

As a result, an iOS package may be compiled against the macOS SDK, producing errors such as:

```text
error: could not build module 'AppKit'
… unable to resolve module dependency: 'UIKit'
```

#### Fix

On Xcode 27+, cross-compiled builds are driven with `--triple`.

SwiftPM consumes `--triple` itself, ensuring every sub-invocation uses a consistent target configuration.

macOS builds are not affected by the flag ordering issue because the host and target are the same. Therefore, macOS continues to use the existing `--arch` / `-Xswiftc` path.

This also avoids a deployment-target regression, because:

```bash
--triple <macos-min>
```

is rejected when the requested minimum macOS version is below the SDK floor.

### 2. Product directory moved

Xcode 27 changed SwiftPM's build layout.

Products are now located under:

```text
out/Products/<Config>
```

instead of:

```text
<arch>-apple-macosx/<config>
```

This applies to every target, including macOS.

Because the old path was hard-coded, the search path no longer exists. As a result, even macOS builds fail during linking with errors like:

```text
library '…' not found
```

#### Fix

On Xcode 27+, resolve the product directory through the `<configuration>` symlink created by SwiftPM in the build directory.

## Gating

- `--triple` build command:
  - cross-compiling
  - Xcode ≥ 27

- symlink-based search path:
  - Xcode ≥ 27
  - all targets

- Xcode ≤ 26:
  - everything is unchanged

The Xcode version is detected using:

```bash
xcrun xcodebuild -version
```

If the version cannot be determined, the legacy path is used.

## Testing

Tested with Xcode 27:
```bash
TEST_SWIFT_RS=true cargo test --features build
```