### PR TITLE
Fix Xcode 27 iOS builds: deployment-target floor, relocated products dir, internalized @_cdecl exports (extends #76)

### DIFF
--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -299,15 +299,13 @@ impl SwiftLinker {
                 self.visionos_min_version.as_deref(),
             );
 
-            // Xcode 27's SwiftPM appends its own host `-sdk`/`-target` *after* any
-            // `-Xswiftc` flags we pass, so the historical per-`swiftc` SDK/target
-            // overrides (below) stopped taking effect and a cross-compiled package
-            // (e.g. iOS) ended up built against the host macOS SDK, failing with
-            // errors like `could not build module 'AppKit'`. From Xcode 27 on we
-            // instead drive the whole build with `--triple`, which SwiftPM consumes
-            // itself so every `swiftc`/`clang` invocation gets a consistent
-            // SDK/target. Older toolchains keep the original behavior untouched.
-            let use_triple = xcode_major_version().map(|v| v >= 27).unwrap_or(false);
+            // Xcode 27's SwiftPM appends the host -sdk/-target after the -Xswiftc
+            // overrides below, so cross builds compile against the host SDK. Pass
+            // --triple there instead. macOS (host == target) is unaffected and
+            // keeps the legacy path.
+            let xcode27 = xcode_major_version().map(|v| v >= 27).unwrap_or(false);
+            let cross_compiling = !matches!(rust_target.os, RustTargetOS::MacOS);
+            let use_triple = cross_compiling && xcode27;
 
             command
                 // Build the package (duh)
@@ -327,13 +325,10 @@ impl SwiftLinker {
             command.args(["--build-path", &out_path.display().to_string()]);
 
             if !use_triple {
+                // Override the SDK and target on each swiftc instance.
                 command
-                    // Override SDK path for each swiftc instance.
-                    // Necessary for iOS compilation.
                     .args(["-Xswiftc", "-sdk"])
                     .args(["-Xswiftc", sdk_path.trim()])
-                    // Override target triple for each swiftc instance.
-                    // Necessary for iOS compilation.
                     .args(["-Xswiftc", "-target"])
                     .args(["-Xswiftc", &swift_target_triple]);
             }
@@ -348,15 +343,11 @@ impl SwiftLinker {
                 panic!("Failed to compile swift package {}", package.name);
             }
 
-            let search_path = if use_triple {
-                // With `--triple` SwiftPM emits products under the real target
-                // triple, so resolve through the `<configuration>` symlink it
-                // creates in the build directory rather than hard-coding the folder
-                // name (newer toolchains moved it to e.g. `out/Products/...`).
+            let search_path = if xcode27 {
+                // Xcode 27 relocated products under out/Products/*; reach them via
+                // the `<configuration>` symlink rather than a fixed path.
                 out_path.join(configuration)
             } else {
-                // The legacy path forces the build onto the host, so the products
-                // always land under `<arch>-apple-macosx`.
                 out_path
                     .join(format!("{}-apple-macosx", arch))
                     .join(configuration)
@@ -397,8 +388,7 @@ fn clang_link_search_path() -> String {
     panic!("clang is missing search paths");
 }
 
-/// The major version of the active Xcode (e.g. `27`), or `None` if it can't be
-/// determined. Used to decide how to pass the SDK/target to `swift build`.
+/// Major version of the active Xcode (e.g. `27`), or `None` if undetectable.
 fn xcode_major_version() -> Option<u32> {
     let output = Command::new("xcrun")
         .args(["xcodebuild", "-version"])
@@ -408,7 +398,7 @@ fn xcode_major_version() -> Option<u32> {
         return None;
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    // The first line looks like `Xcode 27.0`.
+    // e.g. "Xcode 27.0"
     let first_line = stdout.lines().next()?;
     let version = first_line.strip_prefix("Xcode ")?.trim();
     version.split('.').next()?.parse().ok()

--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -299,24 +299,46 @@ impl SwiftLinker {
                 self.visionos_min_version.as_deref(),
             );
 
+            // Xcode 27's SwiftPM appends its own host `-sdk`/`-target` *after* any
+            // `-Xswiftc` flags we pass, so the historical per-`swiftc` SDK/target
+            // overrides (below) stopped taking effect and a cross-compiled package
+            // (e.g. iOS) ended up built against the host macOS SDK, failing with
+            // errors like `could not build module 'AppKit'`. From Xcode 27 on we
+            // instead drive the whole build with `--triple`, which SwiftPM consumes
+            // itself so every `swiftc`/`clang` invocation gets a consistent
+            // SDK/target. Older toolchains keep the original behavior untouched.
+            let use_triple = xcode_major_version().map(|v| v >= 27).unwrap_or(false);
+
             command
                 // Build the package (duh)
                 .arg("build")
                 // SDK path for regular compilation (idk)
                 .args(["--sdk", sdk_path.trim()])
                 // Release/Debug configuration
-                .args(["-c", configuration])
-                .args(["--arch", arch])
-                // Where the artifacts will be generated to
-                .args(["--build-path", &out_path.display().to_string()])
-                // Override SDK path for each swiftc instance.
-                // Necessary for iOS compilation.
-                .args(["-Xswiftc", "-sdk"])
-                .args(["-Xswiftc", sdk_path.trim()])
-                // Override target triple for each swiftc instance.
-                // Necessary for iOS compilation.
-                .args(["-Xswiftc", "-target"])
-                .args(["-Xswiftc", &swift_target_triple])
+                .args(["-c", configuration]);
+
+            if use_triple {
+                command.args(["--triple", &swift_target_triple]);
+            } else {
+                command.args(["--arch", arch]);
+            }
+
+            // Where the artifacts will be generated to
+            command.args(["--build-path", &out_path.display().to_string()]);
+
+            if !use_triple {
+                command
+                    // Override SDK path for each swiftc instance.
+                    // Necessary for iOS compilation.
+                    .args(["-Xswiftc", "-sdk"])
+                    .args(["-Xswiftc", sdk_path.trim()])
+                    // Override target triple for each swiftc instance.
+                    // Necessary for iOS compilation.
+                    .args(["-Xswiftc", "-target"])
+                    .args(["-Xswiftc", &swift_target_triple]);
+            }
+
+            command
                 .args(["-Xcc", &format!("--target={swift_target_triple}")])
                 .args(["-Xcxx", &format!("--target={swift_target_triple}")]);
 
@@ -326,10 +348,19 @@ impl SwiftLinker {
                 panic!("Failed to compile swift package {}", package.name);
             }
 
-            let search_path = out_path
-                // swift build uses this output folder no matter what is the target
-                .join(format!("{}-apple-macosx", arch))
-                .join(configuration);
+            let search_path = if use_triple {
+                // With `--triple` SwiftPM emits products under the real target
+                // triple, so resolve through the `<configuration>` symlink it
+                // creates in the build directory rather than hard-coding the folder
+                // name (newer toolchains moved it to e.g. `out/Products/...`).
+                out_path.join(configuration)
+            } else {
+                // The legacy path forces the build onto the host, so the products
+                // always land under `<arch>-apple-macosx`.
+                out_path
+                    .join(format!("{}-apple-macosx", arch))
+                    .join(configuration)
+            };
 
             println!("cargo:rerun-if-changed={}", package_path.display());
             println!("cargo:rustc-link-search=native={}", search_path.display());
@@ -364,4 +395,21 @@ fn clang_link_search_path() -> String {
         }
     }
     panic!("clang is missing search paths");
+}
+
+/// The major version of the active Xcode (e.g. `27`), or `None` if it can't be
+/// determined. Used to decide how to pass the SDK/target to `swift build`.
+fn xcode_major_version() -> Option<u32> {
+    let output = Command::new("xcrun")
+        .args(["xcodebuild", "-version"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The first line looks like `Xcode 27.0`.
+    let first_line = stdout.lines().next()?;
+    let version = first_line.strip_prefix("Xcode ")?.trim();
+    version.split('.').next()?.parse().ok()
 }

--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -293,7 +293,7 @@ impl SwiftLinker {
                 arch => arch,
             };
 
-            let swift_target_triple = rust_target.swift_target_triple(
+            let mut swift_target_triple = rust_target.swift_target_triple(
                 &self.macos_min_version,
                 self.ios_min_version.as_deref(),
                 self.visionos_min_version.as_deref(),
@@ -306,6 +306,13 @@ impl SwiftLinker {
             let xcode27 = xcode_major_version().map(|v| v >= 27).unwrap_or(false);
             let cross_compiling = !matches!(rust_target.os, RustTargetOS::MacOS);
             let use_triple = cross_compiling && xcode27;
+
+            // Xcode 27 SDKs reject iOS deployment targets below 15
+            // ("supported deployment target versions is 15.0 to 27.0.x") and
+            // consumers commonly pass lower minimums (tauri passes ios13.0).
+            if xcode27 {
+                clamp_ios_deployment_target(&mut swift_target_triple, 15);
+            }
 
             command
                 // Build the package (duh)
@@ -344,14 +351,33 @@ impl SwiftLinker {
             }
 
             let search_path = if xcode27 {
-                // Xcode 27 relocated products under out/Products/*; reach them via
-                // the `<configuration>` symlink rather than a fixed path.
-                out_path.join(configuration)
+                // Xcode 27 SwiftPM layouts vary by beta. Trust no path unless it
+                // actually CONTAINS the archive: the legacy `<configuration>` dir
+                // can exist yet be empty, while the real products live under
+                // [out/]Products/<Configuration>-<platform>
+                // (e.g. out/Products/Release-iphoneos on 27A5218g).
+                let lib_file = format!("lib{}.a", package.name);
+                let direct = out_path.join(configuration);
+                if direct.join(&lib_file).exists() {
+                    direct
+                } else {
+                    xcode27_products_dir(&out_path, configuration, &lib_file).unwrap_or(direct)
+                }
             } else {
                 out_path
                     .join(format!("{}-apple-macosx", arch))
                     .join(configuration)
             };
+
+            if xcode27 {
+                // Xcode 27's SwiftPM internalizes @_cdecl exports in static
+                // products (they show as local 't' in nm), so consumers fail to
+                // link with "undefined symbols". Promote them back to global.
+                globalize_cdecl_symbols(
+                    &search_path.join(format!("lib{}.a", package.name)),
+                    &package.name,
+                );
+            }
 
             println!("cargo:rerun-if-changed={}", package_path.display());
             println!("cargo:rustc-link-search=native={}", search_path.display());
@@ -402,4 +428,137 @@ fn xcode_major_version() -> Option<u32> {
     let first_line = stdout.lines().next()?;
     let version = first_line.strip_prefix("Xcode ")?.trim();
     version.split('.').next()?.parse().ok()
+}
+
+/// Raise the iOS version embedded in a swift target triple (e.g.
+/// `arm64-apple-ios13.0[-simulator]`) to `min_major` if it is lower.
+/// Xcode 27 SDKs hard-reject deployment targets below iOS 15.
+fn clamp_ios_deployment_target(triple: &mut String, min_major: u32) {
+    let Some(idx) = triple.find("apple-ios") else { return };
+    let head_end = idx + "apple-ios".len();
+    let rest = &triple[head_end..];
+    let (ver, suffix) = match rest.find('-') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, ""),
+    };
+    let major = ver.split('.').next().and_then(|m| m.parse::<u32>().ok());
+    if matches!(major, Some(m) if m > 0 && m < min_major) {
+        *triple = format!("{}{}.0{}", &triple[..head_end], min_major, suffix);
+    }
+}
+
+/// Xcode 27 SwiftPM puts static products under [out/]Products/<Config>-<platform>
+/// (e.g. out/Products/Release-iphoneos). Find the dir that really contains the
+/// archive, matching the configuration case-insensitively by prefix.
+fn xcode27_products_dir(
+    out_path: &std::path::Path,
+    configuration: &str,
+    lib_file: &str,
+) -> Option<std::path::PathBuf> {
+    for base in [out_path.join("Products"), out_path.join("out").join("Products")] {
+        let Ok(entries) = std::fs::read_dir(&base) else { continue };
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_lowercase();
+            if name.starts_with(&configuration.to_lowercase())
+                && entry.path().join(lib_file).exists()
+            {
+                return Some(entry.path());
+            }
+        }
+    }
+    None
+}
+
+/// Xcode 27's SwiftPM internalizes @_cdecl exports in static products (nm shows
+/// them as local 't'), so Rust consumers fail to link. Promote them back to
+/// global with llvm-objcopy (rustup's llvm-tools component — Apple ships none).
+///
+/// Guards, each learned from a distinct linker failure:
+/// - only symbols from the package's OWN object member (archives embed copies
+///   of dependency modules; promoting those in every archive duplicates globals)
+/// - only plain C names not starting with '_' (compiler helpers like
+///   ___swift_closure_destructor repeat)
+/// - only names unique within the archive
+/// Violating any of these crashes Xcode 27's ld with "malformed atom files with
+/// duplicate names" (AtomSymbolTable.cpp:242) — and -ld_classic is removed.
+fn globalize_cdecl_symbols(archive: &std::path::Path, package_name: &str) {
+    if !archive.exists() {
+        return;
+    }
+    let Ok(nm) = Command::new("nm").arg(archive).output() else {
+        return;
+    };
+    let norm = |s: &str| {
+        s.to_lowercase()
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric())
+            .collect::<String>()
+    };
+    let pkg = norm(package_name);
+    let mut in_own_member = false;
+    let mut candidates: Vec<String> = Vec::new();
+    let mut occurrences: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+    for line in String::from_utf8_lossy(&nm.stdout).lines() {
+        if line.ends_with(':') {
+            // Member header — "Tauri.o:" (Xcode 27 nm) or "…/lib.a(Tauri.o):"
+            let header = line.trim_end_matches(':').trim_end_matches(')');
+            let member = header.rsplit('(').next().unwrap_or(header);
+            if let Some(module) = member.strip_suffix(".o") {
+                in_own_member = norm(module) == pkg;
+                continue;
+            }
+        }
+        let mut it = line.split_whitespace();
+        let (Some(_addr), Some(kind), Some(name), None) =
+            (it.next(), it.next(), it.next(), it.next())
+        else {
+            continue;
+        };
+        *occurrences.entry(name.to_string()).or_insert(0) += 1;
+        if !in_own_member || kind != "t" || !name.starts_with('_') {
+            continue;
+        }
+        let bare = &name[1..];
+        // A @_cdecl export is a plain C identifier NOT starting with '_'.
+        let c_named = !bare.is_empty()
+            && !bare.starts_with('_')
+            && bare.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+            && !bare.contains("block_copy_helper")
+            && !bare.contains("block_destroy_helper");
+        if c_named && !candidates.iter().any(|s| s == name) {
+            candidates.push(name.to_string());
+        }
+    }
+    let syms: Vec<String> = candidates
+        .into_iter()
+        .filter(|s| occurrences.get(s).copied().unwrap_or(0) <= 1)
+        .collect();
+    if syms.is_empty() {
+        return;
+    }
+    let Some(objcopy) = rustup_llvm_objcopy() else {
+        println!(
+            "cargo:warning=swift-rs: llvm-objcopy not found (run `rustup component add \
+             llvm-tools`); @_cdecl symbols stay internalized on Xcode 27"
+        );
+        return;
+    };
+    let mut cmd = Command::new(objcopy);
+    for s in &syms {
+        cmd.arg(format!("--globalize-symbol={s}"));
+    }
+    cmd.arg(archive);
+    let _ = cmd.status();
+}
+
+/// llvm-objcopy shipped with rustup's llvm-tools component.
+fn rustup_llvm_objcopy() -> Option<std::path::PathBuf> {
+    let sysroot = Command::new("rustc").args(["--print", "sysroot"]).output().ok()?;
+    let sysroot = String::from_utf8_lossy(&sysroot.stdout).trim().to_string();
+    let host = format!("{}-apple-darwin", std::env::consts::ARCH);
+    let p = std::path::Path::new(&sysroot)
+        .join("lib/rustlib")
+        .join(&host)
+        .join("bin/llvm-objcopy");
+    p.exists().then_some(p)
 }


### PR DESCRIPTION
Builds directly on #76 (its two commits are included with original authorship — this PR supersedes it only in the sense of carrying it plus the rest of the story). With #76 alone, our tauri 2.11 iOS build still failed three more ways on Xcode 27.0 beta (27A5218g); with these fixes it builds, links, exports an IPA, and App Store Connect accepted the upload.

The three additional failure modes (exact error strings for searchability):

**1. `IPHONEOS_DEPLOYMENT_TARGET is set to 13.0, but the range of supported deployment target versions is 15.0 to 27.0.x`**
SDK 27 hard-rejects deployment targets below iOS 15, and consumers commonly pass lower minimums (tauri passes `ios13.0` in the triple). Fixed by clamping the triple's iOS version to 15.0 when Xcode ≥ 27 (`clamp_ios_deployment_target`).

**2. `Undefined symbols for architecture arm64: _run_plugin_command, _string_from_bytes, ...`** — two independent causes:
- Products land at `[out/]Products/<Configuration>-<platform>` (e.g. `out/Products/Release-iphoneos`) on this beta, and the legacy `<configuration>` dir can exist but be **empty** — the link-search path is now whichever dir actually contains `lib<Package>.a` (`xcode27_products_dir`).
- **SwiftPM internalizes `@_cdecl` exports in static products** — `nm` shows them as local `t` instead of global `T`. Fixed by post-processing the archive with `llvm-objcopy --globalize-symbol` (Apple ships no objcopy; rustup's `llvm-tools` component provides one — a `cargo:warning` tells users to install it if missing).

**3. `ld: Assertion failed: (existingFile != newFile && "malformed atom files with duplicate names"), AtomSymbolTable.cpp:242`**
This is what unguarded symbol promotion produces, and `-ld_classic` is removed in Xcode 27 so there's no fallback. The globalization therefore has three guards, each of which we validated against a real failure: only the package's **own** object member (archives embed copies of dependency modules like `SwiftRs.o`), only plain C names not starting with `_` (compiler helpers like `___swift_closure_destructor` / `___swift_memcpy*` legitimately repeat), and only names unique within the archive.

Everything is gated on `xcode_major_version() >= 27`; pre-27 toolchains take exactly the code path they take today.

Debugging note that may save the next person time: this beta's `nm` prints archive member headers as bare `Member.o:` rather than `archive(member):`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
