### PR TITLE
Don't let swift build modify the Swift package's source directory

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,6 +32,15 @@ jobs:
         env:
           TEST_SWIFT_RS: "true"
         run: cargo +${{ matrix.rust }} test --features build
+      - name: Ensure build scripts didn't modify the source tree
+        # `swift build` writes Package.resolved into the swift package's source
+        # directory, which makes `cargo package`/`cargo publish` fail verification.
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::The source tree was modified by a build script:"
+            git status --porcelain
+            exit 1
+          fi
       - name: Check Code Formatting
         run: cargo +${{ matrix.rust }} fmt --all -- --check
       - name: Lints

--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use std::{env, fmt::Display, path::Path, path::PathBuf, process::Command};
+use std::{env, fmt::Display, fs, path::Path, path::PathBuf, process::Command};
 
 use serde::Deserialize;
 
@@ -161,6 +161,153 @@ impl RustTarget {
     }
 }
 
+/// State that `swift build` writes into the package's source directory,
+/// no matter where `--build-path` points.
+///
+/// Cargo forbids build scripts from touching anything outside `OUT_DIR`, so
+/// leaving these behind makes `cargo package`/`cargo publish` fail verification
+/// with "Source directory was modified by build.rs during cargo publish".
+const SWIFTPM_SOURCE_STATE: [&str; 2] = ["Package.resolved", ".swiftpm"];
+
+enum Snapshot {
+    /// Didn't exist before the build, so anything there afterwards is ours to remove.
+    Missing,
+    File(Vec<u8>),
+    /// A directory (or something we can't read); left untouched either way.
+    Preexisting,
+}
+
+/// Restores [`SWIFTPM_SOURCE_STATE`] when dropped, including while unwinding
+/// from a failed build, so the package's source directory comes out of
+/// `swift build` exactly as it went in.
+struct SourceStateGuard {
+    entries: Vec<(PathBuf, Snapshot)>,
+}
+
+impl SourceStateGuard {
+    fn new(package_path: &Path) -> Self {
+        let entries = SWIFTPM_SOURCE_STATE
+            .iter()
+            .map(|name| {
+                let path = package_path.join(name);
+                let snapshot = match fs::read(&path) {
+                    Ok(contents) => Snapshot::File(contents),
+                    Err(_) if path.exists() => Snapshot::Preexisting,
+                    Err(_) => Snapshot::Missing,
+                };
+                (path, snapshot)
+            })
+            .collect();
+
+        Self { entries }
+    }
+}
+
+impl Drop for SourceStateGuard {
+    fn drop(&mut self) {
+        for (path, snapshot) in &self.entries {
+            match snapshot {
+                Snapshot::Missing => {
+                    let _ = if path.is_dir() {
+                        fs::remove_dir_all(path)
+                    } else {
+                        fs::remove_file(path)
+                    };
+                }
+                Snapshot::File(contents) => {
+                    if fs::read(path).ok().as_ref() != Some(contents) {
+                        let _ = fs::write(path, contents);
+                    }
+                }
+                Snapshot::Preexisting => {}
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SourceStateGuard, SWIFTPM_SOURCE_STATE};
+    use std::{fs, path::PathBuf};
+
+    /// A scratch package directory, removed when the test finishes.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!("swift-rs-test-{name}"));
+            let _ = fs::remove_dir_all(&path);
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn removes_state_the_build_created() {
+        let dir = TempDir::new("created");
+
+        {
+            let _guard = SourceStateGuard::new(&dir.0);
+            fs::write(dir.0.join("Package.resolved"), b"generated").unwrap();
+            fs::create_dir_all(dir.0.join(".swiftpm").join("configuration")).unwrap();
+        }
+
+        for artifact in SWIFTPM_SOURCE_STATE {
+            assert!(!dir.0.join(artifact).exists(), "{artifact} was left behind");
+        }
+    }
+
+    #[test]
+    fn restores_a_checked_in_lockfile() {
+        let dir = TempDir::new("checked-in");
+        let resolved = dir.0.join("Package.resolved");
+        fs::write(&resolved, b"original").unwrap();
+
+        {
+            let _guard = SourceStateGuard::new(&dir.0);
+            fs::write(&resolved, b"rewritten by swift build").unwrap();
+        }
+
+        assert_eq!(fs::read(&resolved).unwrap(), b"original");
+    }
+
+    #[test]
+    fn leaves_a_preexisting_directory_alone() {
+        let dir = TempDir::new("preexisting");
+        let swiftpm = dir.0.join(".swiftpm");
+        fs::create_dir_all(&swiftpm).unwrap();
+        fs::write(swiftpm.join("keep-me"), b"user data").unwrap();
+
+        drop(SourceStateGuard::new(&dir.0));
+
+        assert_eq!(fs::read(swiftpm.join("keep-me")).unwrap(), b"user data");
+    }
+
+    #[test]
+    fn cleans_up_when_the_build_panics() {
+        let dir = TempDir::new("panicking");
+        let resolved = dir.0.join("Package.resolved");
+
+        let result = std::panic::catch_unwind({
+            let dir = dir.0.clone();
+            move || {
+                let _guard = SourceStateGuard::new(&dir);
+                fs::write(dir.join("Package.resolved"), b"generated").unwrap();
+                panic!("Failed to compile swift package");
+            }
+        });
+
+        assert!(result.is_err());
+        assert!(!resolved.exists(), "Package.resolved survived the panic");
+    }
+}
+
 struct SwiftPackage {
     name: String,
     path: PathBuf,
@@ -276,6 +423,10 @@ impl SwiftLinker {
                 .args(["-Xswiftc", &swift_target_triple])
                 .args(["-Xcc", &format!("--target={swift_target_triple}")])
                 .args(["-Xcxx", &format!("--target={swift_target_triple}")]);
+
+            // `swift build` writes Package.resolved (and sometimes .swiftpm) into
+            // the package source directory; undo that once the build is done.
+            let _source_state_guard = SourceStateGuard::new(&package_path);
 
             if !command.status().unwrap().success() {
                 panic!("Failed to compile swift package {}", package.name);

--- a/src-rs/test-build.rs
+++ b/src-rs/test-build.rs
@@ -15,6 +15,9 @@ fn main() {
         SwiftLinker::new("10.15")
             .with_ios("11")
             .with_package("test-swift", "tests/swift-pkg")
+            // Has a remote dependency, so SwiftPM writes a Package.resolved that
+            // must not be left behind; see tests/test_source_dir.rs.
+            .with_package("test-swift-remote", "tests/swift-pkg-remote")
             .link();
     }
 }

--- a/tests/swift-pkg-remote/Package.swift
+++ b/tests/swift-pkg-remote/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "test-swift-remote",
+    platforms: [
+        .macOS(.v11),
+    ],
+    products: [
+        .library(
+            name: "test-swift-remote",
+            type: .static,
+            targets: ["test-swift-remote"]),
+    ],
+    dependencies: [
+        // Exists purely so that SwiftPM has something to pin: it only writes
+        // Package.resolved into this directory when the graph contains a remote
+        // dependency, and that file is what `cargo package` trips over. This is
+        // swift-rs' own published package so no third party is involved, and the
+        // target below deliberately doesn't use it, so nothing extra is compiled
+        // or linked.
+        .package(url: "https://github.com/Brendonovich/swift-rs", .exact("1.0.7"))
+    ],
+    targets: [
+        .target(
+            name: "test-swift-remote",
+            dependencies: [],
+            path: ".")
+    ]
+)

--- a/tests/swift-pkg-remote/lib.swift
+++ b/tests/swift-pkg-remote/lib.swift
@@ -1,0 +1,4 @@
+// Placeholder so the package has something to build. The point of this package
+// is its remote dependency, not its code — see Package.swift.
+
+func swiftRsRemoteDependencyTestPlaceholder() {}

--- a/tests/test_source_dir.rs
+++ b/tests/test_source_dir.rs
@@ -1,0 +1,36 @@
+//! Regression test for build scripts leaving state in the Swift package's source directory.
+//!
+//! `swift build` writes `Package.resolved` (and sometimes `.swiftpm`) next to
+//! `Package.swift`, no matter where `--build-path` points. Cargo forbids build
+//! scripts from modifying anything outside `OUT_DIR`, so anything left behind
+//! makes `cargo package`/`cargo publish` fail verification with
+//! "Source directory was modified by build.rs during cargo publish".
+//!
+//! Needs to be run with the env var `TEST_SWIFT_RS=true`, so that the build
+//! script has actually built the test swift package.
+
+use std::{env, path::Path};
+
+#[test]
+fn swift_build_leaves_package_dir_untouched() {
+    if env::var("TEST_SWIFT_RS").unwrap_or_else(|_| "false".into()) != "true" {
+        // The build script didn't run `swift build`, so there is nothing to assert.
+        return;
+    }
+
+    let tests_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+
+    // `swift-pkg-remote` is the one that matters: SwiftPM only writes
+    // Package.resolved when the graph has a remote dependency to pin.
+    for package in ["swift-pkg", "swift-pkg-remote"] {
+        for artifact in ["Package.resolved", ".swiftpm"] {
+            let path = tests_dir.join(package).join(artifact);
+            assert!(
+                !path.exists(),
+                "{} was left in the swift package source directory by build.rs, \
+                 which breaks `cargo package`",
+                path.display()
+            );
+        }
+    }
+}


### PR DESCRIPTION
# Don't let `swift build` modify the Swift package's source directory
 
## Problem
 
Any crate that uses `SwiftLinker` fails `cargo package` / `cargo publish`:
 
```
   Verifying app_window v0.3.4 (/Users/drew/Code/app_window)
   Compiling app_window v0.3.4 (/Users/drew/Code/app_window/target/package/app_window-0.3.4)
error: failed to verify package tarball
 
Caused by:
  Source directory was modified by build.rs during cargo publish. Build scripts should not modify anything outside of OUT_DIR.
  Added: /Users/drew/Code/app_window/target/package/app_window-0.3.4/SwiftAppWindow/Package.resolved
```
 
`cargo package` unpacks the tarball, builds it, and then checks that nothing
outside `OUT_DIR` changed. `SwiftLinker::link` shells out to `swift build`, and
SwiftPM writes its resolved-dependency lockfile to `<package>/Package.resolved`
— next to `Package.swift`, in the package's *source* directory. (It does this
whenever the dependency graph has something remote to pin; packages whose
dependencies are all local `path:` ones get no lockfile, which is why this only
bites some users.) There is
no SwiftPM flag to relocate it: `--build-path` only moves build artifacts, and
`--disable-automatic-resolution` requires a `Package.resolved` to already exist.
 
So the file lands in the unpacked source tree, cargo notices, and verification
fails. Downstream crates can only publish with `--no-verify`.
 
SwiftPM can also drop a `.swiftpm/` directory in the same place, for the same
reason.
 
## Solution
 
Snapshot SwiftPM's source-directory state before invoking `swift build` and
restore it afterwards, in `src-rs/build.rs`:
 
- If `Package.resolved` / `.swiftpm` didn't exist before the build, remove what
  SwiftPM created.
- If it did exist, restore the original bytes if SwiftPM rewrote it — a build
  script has no business editing a checked-in lockfile either.
- Anything else (e.g. a pre-existing `.swiftpm` directory) is left alone.
 
The restore runs from a `Drop` impl, so the source directory is cleaned up even
when the Swift build fails and `link` panics.
 
`swift build` still gets to resolve dependencies normally during the build; only
the leftover state is reverted. Re-resolution on each build is cheap, since the
resolved dependencies and workspace state live under the `--build-path` inside
`OUT_DIR` and are unaffected.
 
## Testing
 
Three layers, all on the existing macOS CI job:
 
1. **Unit tests** in `src-rs/build.rs` covering the restore logic directly, with
   no Swift toolchain required (so they run on non-Apple hosts too): state
   created by the build is removed, a checked-in `Package.resolved` is restored
   byte-for-byte, a pre-existing `.swiftpm` directory with user data is left
   alone, and cleanup still happens when the build panics.
 
2. **A new test Swift package with a remote dependency**,
   `tests/swift-pkg-remote`, plus `tests/test_source_dir.rs` asserting that no
   `Package.resolved` or `.swiftpm` is left in either test package.
 
   The remote dependency is the whole point of the package. SwiftPM only writes
   `Package.resolved` when the graph contains something remote to pin, and the
   existing `tests/swift-pkg` and `example/swift-lib` declare only local `path:`
   dependencies — so neither reproduces this bug. The new package depends on
   swift-rs' own published package at `.exact("1.0.7")`, so no third party is
   introduced, and its target deliberately doesn't use the dependency, so
   nothing extra is compiled or linked.
 
3. **A "Ensure build scripts didn't modify the source tree" CI step** that fails
   if `git status --porcelain` is non-empty after the example and test suite are
   built. Catches this class of bug for any artifact not enumerated above.
 
### CI evidence
 
Verified on macOS CI by running the same tree with the guard call removed:
 
| | Guard removed | With fix |
|---|---|---|
| `Run Tests` | **fail** — `tests/swift-pkg-remote/Package.resolved was left in the swift package source directory by build.rs` | pass |
| `Ensure build scripts didn't modify the source tree` | not reached | pass |
| `Test example`, `Check Code Formatting` | pass | pass |
 
Three of the four unit tests likewise fail with the guard disabled.
 
### Pre-existing failure, not addressed here
 
The `Lints` job (`cargo clippy -- -D warnings`) fails on `main` and continues to
fail here, on two warnings that newer clippy promotes to errors in files this
change doesn't touch:
 
- `src-rs/lib.rs:10` — unused import: `autorelease::*`
- `src-rs/swift.rs:34` — `mismatched_lifetime_syntaxes` on `swift_ref`
 
Left alone to keep this change scoped to the packaging bug.